### PR TITLE
Add role name to meta file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ To use this role add this to your playbook:
 
     - hosts: servers
       roles:
-         - { role: domenblenkus.common }
+         - { role: genialis.common }
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: common
-  author: Domen Blenkuš
+  author: Genialis
   description: Common configutation for CentOS 7 server.
   license: GPLv3
   min_ansible_version: 1.2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: common
   author: Domen Blenkuš
   description: Common configutation for CentOS 7 server.
   license: GPLv3


### PR DESCRIPTION
Issue: In Ansible Galaxy, the role is named "ansible_common" instead of "common".

Changes: updated configuration in meta/main.yml.
