### PR TITLE
Port to Ansible 2.9

### DIFF
--- a/tasks/guest_additions.yml
+++ b/tasks/guest_additions.yml
@@ -1,17 +1,19 @@
 ---
 
 - name: Install prerequests for VirtualBox Guest Additions
-  package: name={{ item }} state=present
-  with_items:
-    - dkms
-    - gcc
-    - make
+  package:
+    name:
+      - dkms
+      - gcc
+      - make
+    state: present
 
 - name: Update kernel
-  package: name={{ item }} state=latest
-  with_items:
-    - kernel
-    - kernel-devel
+  package:
+    name:
+      - kernel
+      - kernel-devel
+    state: latest
   register: common_update_kernel_res
 
 - name: Restart server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   assert:
     that:
       - ansible_distribution in ["CentOS", "RedHat"]
-      - ansible_distribution_version | version_compare('7.4', '>=')
+      - ansible_distribution_version is version_compare('7.4', '>=')
 
 - name: Get remote username
   become: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,16 +15,16 @@
 - name: Save remote username to `remote_user`
   set_fact: remote_user="{{ common_whoami_res.stdout_lines[0] }}"
 
-- include: sys_packages.yml
+- include_tasks: sys_packages.yml
 
-- include: python.yml
+- include_tasks: python.yml
 
-- include: ssh.yml
+- include_tasks: ssh.yml
 
-- include: security.yml
+- include_tasks: security.yml
   when: common_include_security
 
-- include: config.yml
+- include_tasks: config.yml
 
-- include: guest_additions.yml
+- include_tasks: guest_additions.yml
   when: common_include_guest_additions

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -1,13 +1,14 @@
 ---
 
 - name: Install Python utilities
-  package: name={{ item }} state=present
-  with_items:
-    - python-virtualenv
-    # NOTE: python-ipython-console package provides IPython for running in a
-    # terminal and requires far less dependencies than the python-ipython
-    # package which provides the full IPython.
-    - python-ipython-console
+  package:
+    name:
+      - python-virtualenv
+      # NOTE: python-ipython-console package provides IPython for running in a
+      # terminal and requires far less dependencies than the python-ipython
+      # package which provides the full IPython.
+      - python-ipython-console
+    state: present
 
 - name: Install Python 3.4
   package: name=python34 state=present

--- a/tasks/sys_packages.yml
+++ b/tasks/sys_packages.yml
@@ -14,7 +14,7 @@
     # NOTE: Output of 'yum repolist' may start with '*' if the repository has
     # metalink data and the latest metadata is not local or with '!' if the
     # repository has metadata that is expired.
-    when: not common_repos_res.stdout | search('\n(\*|!)?' + item)
+    when: not common_repos_res.stdout is search('\n(\*|!)?' + item)
 
   - name: Install EPEL repository package
     yum:
@@ -23,7 +23,7 @@
     # NOTE: Output of 'yum repolist' may start with '*' if the repository has
     # metalink data and the latest metadata is not local or with '!' if the
     # repository has metadata that is expired.
-    when: not common_repos_res.stdout | search('\n(\*|!)?' + 'epel')
+    when: not common_repos_res.stdout is search('\n(\*|!)?' + 'epel')
 
   when: ansible_distribution == "RedHat"
 

--- a/tasks/sys_packages.yml
+++ b/tasks/sys_packages.yml
@@ -32,13 +32,14 @@
   when: ansible_distribution == "CentOS"
 
 - name: Install basic system packages
-  package: name={{ item }} state=present
-  with_items:
-   - bash-completion
-   - htop
-   - screen
-   - vim
-   - wget
+  package:
+    name:
+      - bash-completion
+      - htop
+      - screen
+      - vim
+      - wget
+    state: present
 
 - name: Install ntp
   package: name=ntp state=present

--- a/tasks/sys_packages.yml
+++ b/tasks/sys_packages.yml
@@ -39,10 +39,8 @@
       - screen
       - vim
       - wget
+      - ntp
     state: present
-
-- name: Install ntp
-  package: name=ntp state=present
 
 - name: Ensure ntp is enabled and started
   service: name=ntpd enabled=yes state=started


### PR DESCRIPTION
Changes:
- Replace deprecated include with include_tasks:
From Ansible 2.4+, include keyword is deprecated. For dynamic
inclusions, include_tasks is preferred and required in Ansible 2.8+.
- Filters are replaced with Jinja tests
- Package modules support lists of packages. Deprecated with_items notation is replaced.