### PR TITLE
Improve ssh security and logs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,12 @@ command as user who connects to the server.
 |                                    |          | added to ``remote_user``'s                |           |                                                                |
 |                                    |          | ``authorized_keys file``.                 |           |                                                                |
 +------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------------------------------+
+| ``common_audit_num_logs``          |   int    | Number of log files that auditd will      |     no    | ``100``                                                        |
+|                                    |          | keep before they are removed.             |           |                                                                |
++------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------------------------------+
+| ``common_audit_max_log_file``      |   int    | Maximum file size of each auditd          |     no    | ``20``                                                         |
+|                                    |          | log file.                                 |           |                                                                |
++------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------------------------------+
 | ``vaulted_common_root_password``   |  string  | ``root``'s password. It must be hashed    |     no    | ``""``                                                         |
 |                                    |          | and stored in Ansible Vault for security  |           |                                                                |
 |                                    |          | reasons. See `Ansible documentation`_ for |           |                                                                |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ common_selinux_permisive: false
 common_ssh_allowed_ips: []
 common_ssh_authorized_keys: []
 
+common_audit_num_logs: 100
+common_audit_max_log_file: 20
+
 vaulted_common_root_password: ""
 
 common_root_ps1: '${BGREEN}\u@\h${NORMAL}:${BBLUE}\w${NORMAL}\\$ '

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,3 +8,6 @@
 
 - name: Restart systemd-journald
   service: name=systemd-journald state=restarted
+
+- name: Restart auditd
+  service: name=auditd state=restarted use=service

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -27,6 +27,62 @@
     state: present
   notify: Restart ssh
 
+- name: Disable SSH X11 forwarding
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#?X11Forwarding\\s+(yes|no)"
+    line: "X11Forwarding no"
+    state: present
+  notify: Restart ssh
+
+- name: Ensure SSH MaxAuthTries is set to 4 or less
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^(#\\s*)?MaxAuthTries\\s+\\d+"
+    line: "MaxAuthTries 4"
+    state: present
+  notify: Restart ssh
+
+- name: Configure SSH idle timeout
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^(#\\s*)?ClientAliveInterval\\s+\\d+"
+    line: "ClientAliveInterval 300"
+    state: present
+  notify: Restart ssh
+
+- name: Configure SSH idle timeout alive count
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^(#\\s*)?ClientAliveCountMax\\s+\\d+"
+    line: "ClientAliveCountMax 2"
+    state: present
+  notify: Restart ssh
+
+- name: Disable SSH TCPKeepAlive
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#?TCPKeepAlive\\s+(yes|no)"
+    line: "TCPKeepAlive no"
+    state: present
+  notify: Restart ssh
+
+- name: Configure SSH LoginGraceTime
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^(#\\s*)?LoginGraceTime\\s+\\d+\\w?"
+    line: "LoginGraceTime 60"
+    state: present
+  notify: Restart ssh
+
+- name: Disable SSH TCP forwarding
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#?AllowTcpForwarding\\s+(yes|no)"
+    line: "AllowTcpForwarding no"
+    state: present
+  notify: Restart ssh
+
 - name: Ensure firewalld is enabled and started
   service: name=firewalld enabled=yes state=started
 

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -89,3 +89,19 @@
 - name: Set SELinux to permisive
   selinux: policy=targeted state=permissive
   when: common_selinux_permisive == true
+
+- name: Set the number of audit log files
+  lineinfile:
+    dest: /etc/audit/auditd.conf
+    regexp: "^num_logs\\s*=\\s*\\d+"
+    line: "num_logs = {{ common_audit_num_logs }}"
+    state: present
+  notify: Restart auditd
+
+- name: Configure audit log storage size
+  lineinfile:
+    dest: /etc/audit/auditd.conf
+    regexp: "^max_log_file\\s*=\\s*\\d+"
+    line: "max_log_file = {{ common_audit_max_log_file }}"
+    state: present
+  notify: Restart auditd


### PR DESCRIPTION
To improve security and compliance with CIS benchmarks, SSH security was hardened:
- Replace TCPKeepAlive (spoofable) with ClientAliveInterval settings and set them to values suggested by CIS benchmarks
- Disable X11 and TCP forwarding
- Increase Log level and audit retention policy