### PR TITLE
Improve security and service monitoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,15 +67,6 @@ command as user who connects to the server.
 | ``common_audit_max_log_file``      |   int    | Maximum file size of each auditd          |     no    | ``20``                                                         |
 |                                    |          | log file.                                 |           |                                                                |
 +------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------------------------------+
-| ``vaulted_common_root_password``   |  string  | ``root``'s password. It must be hashed    |     no    | ``""``                                                         |
-|                                    |          | and stored in Ansible Vault for security  |           |                                                                |
-|                                    |          | reasons. See `Ansible documentation`_ for |           |                                                                |
-|                                    |          | more details.                             |           |                                                                |
-|                                    |          |                                           |           |                                                                |
-|                                    |          | .. WARNING::                              |           |                                                                |
-|                                    |          |    Password will be disabled if this      |           |                                                                |
-|                                    |          |    setting is left blank.                 |           |                                                                |
-+------------------------------------+----------+-------------------------------------------+-----------+----------------------------------------------------------------+
 | ``vaulted_common_user_password``   |  string  | ``remote_user``'s password. It must be    |     no    |                                                                |
 |                                    |          | hashed and stored in Ansible Vault for    |           |                                                                |
 |                                    |          | security reasons. See `Ansible            |           |                                                                |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,6 @@ common_ssh_authorized_keys: []
 common_audit_num_logs: 100
 common_audit_max_log_file: 20
 
-vaulted_common_root_password: ""
-
 common_root_ps1: '${BGREEN}\u@\h${NORMAL}:${BBLUE}\w${NORMAL}\\$ '
 common_user_ps1: '${BLUE}(${RED}\w${BLUE}) ${NORMAL}\h ${RED}\\$ ${NORMAL}'
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,3 +11,7 @@
 
 - name: Restart auditd
   service: name=auditd state=restarted use=service
+
+- name: Re-exec systemd
+  systemd:
+    daemon_reexec: yes

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,6 +14,14 @@
     dest: /etc/systemd/journald.conf
   notify: Restart systemd-journald
 
+- name: Configure systemd memory accounting
+  lineinfile:
+    dest: /etc/systemd/system.conf
+    regexp: "^(#\\s*)?DefaultMemoryAccounting=(yes|no)"
+    line: "DefaultMemoryAccounting=yes"
+    state: present
+  notify: Re-exec systemd
+
 - name: Configure .bashrc files
   template:
     src: home/bashrc.j2

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -3,7 +3,7 @@
 - name: Set root password
   user:
     name: root
-    password: "{{ vaulted_common_root_password }}"
+    password_lock: True
 
 - name: Set user's password
   user:


### PR DESCRIPTION
- Default root password is locked. We run superuser commands with sudo.
- Measure memory usage for systemd services